### PR TITLE
Adds backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is an update/rework of [Osmosis Wrench](https://www.nexusmods.com/skyrimspecialedition/users/2801784)'s [Custom Skills Menu](https://www.nexusmods.com/skyrimspecialedition/mods/62423?tab=description) for compatibility with Custom Skills Framework v3.
 
 > [!IMPORTANT]
-> The [original mod](https://www.nexusmods.com/skyrimspecialedition/mods/62423) is hard requirement! Please support [Osmosis Wrench](https://www.nexusmods.com/skyrimspecialedition/users/2801784) too - this mod wouldn't be here if not for their hard work.
+> The [original mod](https://www.nexusmods.com/skyrimspecialedition/mods/62423) is a hard requirement! Please support [Osmosis Wrench](https://www.nexusmods.com/skyrimspecialedition/users/2801784) too - this mod wouldn't be here if not for their hard work.
 
 ## Basics
 

--- a/Source/Scripts/metaSkillMenuScript.psc
+++ b/Source/Scripts/metaSkillMenuScript.psc
@@ -65,17 +65,27 @@ EndFunction
 function load_data()
     string poolName = "menuInfoPool"
     ; turn files to array of strings
-    int CSFFiles = JValue.addToPool(JValue.readFromDirectory("data/SKSE/Plugins/CustomSkills/", ".json"), poolName)
-    jvalue.writetofile(CSFFiles, "data/interface/MetaSkillsMenu/rawData.json")
+    int jCsfFilesV3 = JValue.addToPool(JValue.readFromDirectory("data/SKSE/Plugins/CustomSkills/", ".json"), poolName)
+    jvalue.writetofile(jCsfFilesV3, "data/interface/MetaSkillsMenu/rawData.json")
+
+    ; get contents of Custom Skills directory
+    int jCsfFilesV2 = JValue.addToPool(JArray.objectWithStrings(JContainers.contentsOfDirectoryAtPath("NetScriptFramework/Plugins", ".txt")), poolName)
+
+    int jConfigsV2 = JValue.addToPool(JValue.evalLuaObj(jCsfFilesV2, "return msm.truncateV2(collection)"), poolName)
 
     ; read saved data
     int hideData = tryGetObjFromFile("data/interface/MetaSkillsMenu/MSMHidden.json", poolName)
     int savedData = tryGetObjFromFile("data/interface/MetaSkillsMenu/MSMData.json", poolName)
 
-    ; pre-format our data
+    ; First we overwrite the CSF .json data with MSMData.json
     int loadedConfigs = JValue.addToPool(JMap.object(), poolName)
     JMap.setObj(loadedConfigs, "original", savedData)
-    JMap.setObj(loadedConfigs, "new", CSFFiles)
+    JMap.setObj(loadedConfigs, "new", jCsfFilesV3)
+    int configsTrimmedV3 = JValue.addToPool(JValue.evalLuaObj(loadedConfigs, "return msm.loadCustomMenu(jobject)"), poolName)
+
+    ; Then we overwrite the CSF v2 data with our combined data
+    JMap.setObj(loadedConfigs, "original", configsTrimmedV3)
+    Jmap.setObj(loadedConfigs, "new", jCsfFilesV2)
     int allConfigsTrimmed = JValue.addToPool(JValue.evalLuaObj(loadedConfigs, "return msm.loadCustomMenu(jobject)"), poolName)
 
     ; process hidden data also

--- a/Source/Scripts/metaSkillMenuScript.psc
+++ b/Source/Scripts/metaSkillMenuScript.psc
@@ -62,31 +62,32 @@ int function tryGetObjFromFile(string filePath, string poolName)
     endif
 EndFunction
 
+; run on game load
+; could be cleaned up and wrapped into loops, but I'm not sure if the comprehensibility trade-off is worth it
 function load_data()
     string poolName = "menuInfoPool"
     ; turn files to array of strings
     int jCsfFilesV3 = JValue.addToPool(JValue.readFromDirectory("data/SKSE/Plugins/CustomSkills/", ".json"), poolName)
     jvalue.writetofile(jCsfFilesV3, "data/interface/MetaSkillsMenu/rawData.json")
 
-    ; get contents of Custom Skills directory
-    int jCsfFilesV2 = JValue.addToPool(JArray.objectWithStrings(JContainers.contentsOfDirectoryAtPath("NetScriptFramework/Plugins", ".txt")), poolName)
-
-    int jConfigsV2 = JValue.addToPool(JValue.evalLuaObj(jCsfFilesV2, "return msm.truncateV2(collection)"), poolName)
+    ; get contents of Custom Skills directory and process it
+    int jCsfFilesV2 = JValue.addToPool(JArray.objectWithStrings(JContainers.contentsOfDirectoryAtPath("data/NetScriptFramework/Plugins", ".txt")), poolName)
+    ;int jConfigsV2 = JValue.addToPool(JValue.evalLuaObj(jCsfFilesV2, "return msm.truncateV2(jobject)"), poolName)
 
     ; read saved data
     int hideData = tryGetObjFromFile("data/interface/MetaSkillsMenu/MSMHidden.json", poolName)
     int savedData = tryGetObjFromFile("data/interface/MetaSkillsMenu/MSMData.json", poolName)
 
-    ; First we overwrite the CSF .json data with MSMData.json
+    ; First we overwrite the CSF v3 .json data with MSMData.json
     int loadedConfigs = JValue.addToPool(JMap.object(), poolName)
     JMap.setObj(loadedConfigs, "original", savedData)
-    JMap.setObj(loadedConfigs, "new", jCsfFilesV3)
-    int configsTrimmedV3 = JValue.addToPool(JValue.evalLuaObj(loadedConfigs, "return msm.loadCustomMenu(jobject)"), poolName)
+    JMap.setObj(loadedConfigs, "new", JValue.addToPool(JValue.evalLuaObj(jCsfFilesV3, "return msm.truncateV3(jobject)"), poolName))
+    int configsTrimmedV3 = JValue.addToPool(JValue.evalLuaObj(loadedConfigs, "return msm.mergeMenuOptionsHelper(jobject)"), poolName)
 
     ; Then we overwrite the CSF v2 data with our combined data
     JMap.setObj(loadedConfigs, "original", configsTrimmedV3)
-    Jmap.setObj(loadedConfigs, "new", jCsfFilesV2)
-    int allConfigsTrimmed = JValue.addToPool(JValue.evalLuaObj(loadedConfigs, "return msm.loadCustomMenu(jobject)"), poolName)
+    Jmap.setObj(loadedConfigs, "new", JValue.addToPool(JValue.evalLuaObj(jCsfFilesV2, "return msm.truncateV2(jobject)"), poolName))
+    int allConfigsTrimmed = JValue.addToPool(JValue.evalLuaObj(loadedConfigs, "return msm.mergeMenuOptionsHelper(jobject)"), poolName)
 
     ; process hidden data also
     int jConfWithHidden = JValue.addToPool(JMap.object(), poolName)

--- a/dist/skse/Plugins/JCData/Lua/msm/init.lua
+++ b/dist/skse/Plugins/JCData/Lua/msm/init.lua
@@ -4,13 +4,13 @@ local msm = {}
 
 -- we receive our collection of every Custom Skill at once
 -- and we return a trimmed version with only what CSM needs
-function msm.truncate(collection)
+function msm.truncateV3(collection)
     local ret = JMap.object()
 
     for filePath, skillSet in pairs(collection) do
         --extract filename
         local fileName = filePath:match("^(.+)%.%w+")
-        local processedSkill = msm.processSkill(fileName, skillSet)
+        local processedSkill = msm.processSkillV3(fileName, skillSet)
 
         --sanity check
         if processedSkill ~= nil then
@@ -22,7 +22,7 @@ function msm.truncate(collection)
 end
 
 -- Trim and format CSF json into only everything that CSM needs
-function msm.processSkill(fileName, skillSet)
+function msm.processSkillV3(fileName, skillSet)
     local showMenu = skillSet["showMenu"]
 
     --sanity check
@@ -54,6 +54,61 @@ function msm.processSkill(fileName, skillSet)
     menuEntry["Disabled"] = 0
 
     return menuEntry
+end
+
+-- from the original CSM
+-- don't broke what ain't fix
+function msm.truncateV2(collection)
+    local ret = JMap.object()
+    local function trim(s)
+        -- from PiL2 20.4
+        return (s:gsub("^%s*(.-)%s*$", "%1"))
+    end
+    for x = 1, #collection do
+        local file = io.open(collection[x], "r")
+        if file == nil then
+            goto continue
+        end
+        local content = file:read "*a"
+        file:close()
+        local t = JMap.object()
+        for k, v in string.gmatch(content, "(%w+) =(.-\n)") do
+            t[k] = v
+            -- cleanup crap
+            t[k] = string.gsub(t[k], "\n", "")
+            t[k] = string.gsub(t[k], " \\ ", "")
+            t[k] = string.gsub(t[k], "\"", "")
+            t[k] = trim(t[k])
+        end
+        if t["Name"]and t["MSM_DoNotShow"] == nil then
+            local r = JMap.object()
+            r["test"] = collection[x]
+            r["Name"] = t["Name"]
+            r["Description"] = t["Description"]
+            r["Skydome"] = t["Skydome"]
+            if t["ShowMenuFile"] == nil or t["LevelFile"] == "" then
+                -- this will be the default action if on new CSF as ShowMenuFile is no longer needed.
+                if t["LevelFile"] == nil or t["LevelFile"] == "" then
+                    r["ShowMenuFile"] = t["RatioFile"]
+                else
+                    r["ShowMenuFile"] = t["LevelFile"]
+                end
+                r["ShowMenuForm"] = 0
+                r["CSFSKSE"] = 1
+            else
+                r["ShowMenuFile"] = t["ShowMenuFile"]
+                r["ShowMenuForm"] = "__formData|"..t["ShowMenuFile"].."|"..t["ShowMenuId"]
+                r["CSFSKSE"] = 0
+            end
+            r["icon_loc"] = "data/interface/MetaSkillsMenu/" .. r["Name"] .. " " .. string.gsub(r["ShowMenuFile"], ".esp", ".dds")
+            r["icon_exists"] = 0
+            r["hidden"] = 0
+             -- construct formdata record
+            ret[collection[x]] = r
+        end
+        ::continue::
+    end
+    return ret
 end
 
 -- Replace new Name, Description, and icon_loc with original
@@ -138,7 +193,7 @@ end
 
 -- forced to use this helper because JContainers only allows one argument
 function msm.loadCustomMenu(settings)
-    return msm.mergeMenuOptions(settings["original"], msm.truncate(settings["new"]))
+    return msm.mergeMenuOptions(settings["original"], msm.truncateV3(settings["new"]))
 end
 
 -- sets value from tableFrom to tableTo if key exists in tableFrom

--- a/dist/skse/Plugins/JCData/Lua/msm/init.lua
+++ b/dist/skse/Plugins/JCData/Lua/msm/init.lua
@@ -82,29 +82,31 @@ function msm.truncateV2(collection)
         end
         if t["Name"]and t["MSM_DoNotShow"] == nil then
             local r = JMap.object()
-            r["test"] = collection[x]
+            r["filePath"] = collection[x]
             r["Name"] = t["Name"]
             r["Description"] = t["Description"]
-            r["Skydome"] = t["Skydome"]
             if t["ShowMenuFile"] == nil or t["LevelFile"] == "" then
                 -- this will be the default action if on new CSF as ShowMenuFile is no longer needed.
                 if t["LevelFile"] == nil or t["LevelFile"] == "" then
-                    r["ShowMenuFile"] = t["RatioFile"]
+                    r["plugin"] = t["RatioFile"]
                 else
-                    r["ShowMenuFile"] = t["LevelFile"]
+                    r["plugin"] = t["LevelFile"]
                 end
                 r["ShowMenuForm"] = 0
                 r["CSFSKSE"] = 1
+                r["Disabled"] = 1
             else
-                r["ShowMenuFile"] = t["ShowMenuFile"]
-                r["ShowMenuForm"] = "__formData|"..t["ShowMenuFile"].."|"..t["ShowMenuId"]
+                r["plugin"] = t["ShowMenuFile"]
+                r["ShowMenu"] = "__formData|"..t["ShowMenuFile"].."|"..t["ShowMenuId"]
                 r["CSFSKSE"] = 0
+                r["Disabled"] = 0
             end
-            r["icon_loc"] = "data/interface/MetaSkillsMenu/" .. r["Name"] .. " " .. string.gsub(r["ShowMenuFile"], ".esp", ".dds")
+            r["icon_loc"] = "data/interface/MetaSkillsMenu/" .. r["Name"] .. " " .. string.gsub(r["plugin"], ".esp", ".dds")
             r["icon_exists"] = 0
             r["hidden"] = 0
+            local fileName = collection[x]:match(".+%/(.+).txt")
              -- construct formdata record
-            ret[collection[x]] = r
+            ret[fileName] = r
         end
         ::continue::
     end
@@ -189,6 +191,11 @@ function msm.transferToHidden(menus, hiddenOptions)
         end
     end
     return hiddenOptions
+end
+
+-- forced to use this helper because JContainers only allows one argument
+function msm.mergeMenuOptionsHelper(collection)
+    return msm.mergeMenuOptions(collection["original"], collection["new"])
 end
 
 -- forced to use this helper because JContainers only allows one argument


### PR DESCRIPTION
Should make Denji backwards-compatible with CSF v2 files. It'll do this by treating them as "originals," and first overwrite them with CSF v3 then `MSMData.json`.

- [ ] Update documentation to reflect this
- [ ] Test a bit more