### PR TITLE
Feat: Add backwards compatibility for CSFv2's showMenu-less menu opening implementation

### DIFF
--- a/Source/Scripts/metaSkillMenuScript.psc
+++ b/Source/Scripts/metaSkillMenuScript.psc
@@ -110,7 +110,6 @@ function load_data()
         string showMenu = JMap.getStr(fileobj, "ShowMenu")
 
         Writelog("Loading skills from file: " + skillId)
-        ;bool isCsfV2 = JMap.getInt(fileobj, "CSFv2") as bool
         if (showMenu == "")
             WriteLog("Legacy or legacy-style skill. Will call CSF with skill ID (" + skillId + ")")
         else
@@ -186,7 +185,6 @@ event SelectedMenu(string eventName, string strArg, float numArg, Form sender)
     ; get chosen skill object from config
     int modObject = JValue.addToPool(JMap.getObj(MSMData, strArg), "menuData")
 
-    ;bool isCsfV2 = JMap.getInt(modObject, "CSFv2")
     string showMenu = JMap.getStr(modObject, "ShowMenu")
 
     if (showMenu == "")

--- a/Source/Scripts/metaSkillMenuScript.psc
+++ b/Source/Scripts/metaSkillMenuScript.psc
@@ -99,19 +99,20 @@ function load_data()
     int jCustomMenuPreFormatted = JValue.addToPool(JMap.getObj(jHiddenReturn, "menus"), poolName)
 
     ; start at the beginning
-    string filekey = jmap.nextkey(jCustomMenuPreFormatted)
+    string skillId = jmap.nextkey(jCustomMenuPreFormatted)
     ; WARNING
     ; We only load skill groups with a `ShowMenu`
-    while filekey
+    while skillId
         string filePoolName = "iterateFilePool"
         ; grab object associated with key
-        int fileobj = JValue.addToPool(jmap.getobj(jCustomMenuPreFormatted, filekey), filePoolName)
+        int fileobj = JValue.addToPool(jmap.getobj(jCustomMenuPreFormatted, skillId), filePoolName)
         string pluginName = jmap.getstr(fileobj, "plugin")
+        string showMenu = JMap.getStr(fileobj, "ShowMenu")
 
-        Writelog("Loading skills from file: " + filekey)
-        bool isCsfV2 = JMap.getInt(fileobj, "CSFv2") as bool
-        if (isCsfV2)
-            WriteLog("CSF v2 skill. Will call CSF with file ID (" + filekey + ")")
+        Writelog("Loading skills from file: " + skillId)
+        ;bool isCsfV2 = JMap.getInt(fileobj, "CSFv2") as bool
+        if (showMenu == "")
+            WriteLog("Legacy or legacy-style skill. Will call CSF with skill ID (" + skillId + ")")
         else
             WriteLog("Using this to display menu: " + JMap.getStr(fileobj, "ShowMenu"))
         endif
@@ -129,8 +130,8 @@ function load_data()
             JMap.setInt(fileobj, "Disabled", 1)
         endif
 
-        ; go to next filekey
-        filekey = jmap.nextkey(jCustomMenuPreFormatted, filekey)
+        ; go to next skillId
+        skillId = jmap.nextkey(jCustomMenuPreFormatted, skillId)
         JValue.cleanPool(filePoolName)
     endwhile
 
@@ -185,12 +186,13 @@ event SelectedMenu(string eventName, string strArg, float numArg, Form sender)
     ; get chosen skill object from config
     int modObject = JValue.addToPool(JMap.getObj(MSMData, strArg), "menuData")
 
-    bool isCsfV2 = JMap.getInt(modObject, "CSFv2")
+    ;bool isCsfV2 = JMap.getInt(modObject, "CSFv2")
+    string showMenu = JMap.getStr(modObject, "ShowMenu")
 
-    if (isCsfV2)
+    if (showMenu == "")
         CustomSkills.OpenCustomSkillMenu(strArg)
     else
-        GlobalVariable showMenuVar = JString.decodeFormStringToForm(JMap.getStr(modObject, "ShowMenu")) as GlobalVariable
+        GlobalVariable showMenuVar = JString.decodeFormStringToForm(showMenu) as GlobalVariable
         showMenuVar.Mod(1.0)
     endif
     

--- a/Source/Scripts/metaSkillMenuScript.psc
+++ b/Source/Scripts/metaSkillMenuScript.psc
@@ -109,7 +109,13 @@ function load_data()
         string pluginName = jmap.getstr(fileobj, "plugin")
 
         Writelog("Loading skills from file: " + filekey)
-        WriteLog("Using this to display menu: " + JMap.getStr(fileobj, "ShowMenu"))
+        bool isCsfV2 = JMap.getInt(fileobj, "CSFv2") as bool
+        if (isCsfV2)
+            WriteLog("CSF v2 skill. Will call CSF with file ID (" + filekey + ")")
+        else
+            WriteLog("Using this to display menu: " + JMap.getStr(fileobj, "ShowMenu"))
+        endif
+        
         WriteLog("Hidden? " + JMap.getInt(fileobj, "hidden"))
         if (game.IsPluginInstalled(pluginName))
             ; if at least one is unhidden, we set it to true
@@ -179,8 +185,15 @@ event SelectedMenu(string eventName, string strArg, float numArg, Form sender)
     ; get chosen skill object from config
     int modObject = JValue.addToPool(JMap.getObj(MSMData, strArg), "menuData")
 
-    GlobalVariable showMenuVar = JString.decodeFormStringToForm(JMap.getStr(modObject, "ShowMenu")) as GlobalVariable
-    showMenuVar.Mod(1.0)
+    bool isCsfV2 = JMap.getInt(modObject, "CSFv2")
+
+    if (isCsfV2)
+        CustomSkills.OpenCustomSkillMenu(strArg)
+    else
+        GlobalVariable showMenuVar = JString.decodeFormStringToForm(JMap.getStr(modObject, "ShowMenu")) as GlobalVariable
+        showMenuVar.Mod(1.0)
+    endif
+    
     UI.CloseCustomMenu()
     JValue.cleanPool("menuData")
 endEvent

--- a/dist/skse/Plugins/JCData/Lua/msm/init.lua
+++ b/dist/skse/Plugins/JCData/Lua/msm/init.lua
@@ -50,6 +50,8 @@ function msm.processSkillV3(fileName, skillSet)
             string.gsub(plugin, ".esp", ".dds")
     menuEntry["icon_exists"] = 0
     menuEntry["plugin"] = plugin
+    -- CSFv2 skills can have a different entry point
+    menuEntry["CSFv2"] = 0
     -- enable it by default; we disable it in Papyrus
     menuEntry["Disabled"] = 0
 
@@ -86,27 +88,26 @@ function msm.truncateV2(collection)
             r["Name"] = t["Name"]
             r["Description"] = t["Description"]
             if t["ShowMenuFile"] == nil or t["LevelFile"] == "" then
-                -- this will be the default action if on new CSF as ShowMenuFile is no longer needed.
+                -- this will be the default action if on CSFv2 as ShowMenuFile is not needed
                 if t["LevelFile"] == nil or t["LevelFile"] == "" then
                     r["plugin"] = t["RatioFile"]
                 else
                     r["plugin"] = t["LevelFile"]
                 end
                 r["ShowMenuForm"] = 0
-                r["CSFSKSE"] = 1
-                r["Disabled"] = 1
+                r["CSFv2"] = 1
             else
                 r["plugin"] = t["ShowMenuFile"]
                 r["ShowMenu"] = "__formData|"..t["ShowMenuFile"].."|"..t["ShowMenuId"]
-                r["CSFSKSE"] = 0
-                r["Disabled"] = 0
+                r["CSFv2"] = 0
             end
             r["icon_loc"] = "data/interface/MetaSkillsMenu/" .. r["Name"] .. " " .. string.gsub(r["plugin"], ".esp", ".dds")
             r["icon_exists"] = 0
             r["hidden"] = 0
-            local fileName = collection[x]:match(".+%/(.+).txt")
+            r["Disabled"] = 0
+            local skillId = collection[x]:gsub(".+%/(.-)%.(.-)%.(.-)%.txt", "%2")
              -- construct formdata record
-            ret[fileName] = r
+            ret[skillId] = r
         end
         ::continue::
     end

--- a/dist/skse/Plugins/JCData/Lua/msm/init.lua
+++ b/dist/skse/Plugins/JCData/Lua/msm/init.lua
@@ -49,7 +49,7 @@ function msm.truncateV3(collection)
             end
             -- process entire skill tree into one CSM selection
             local processedSkill = msm.processSkillV3(skillId, plugin, showMenuId)
-            --sanity check
+            -- sanity check
             if processedSkill ~= nil then
                 ret[skillId] = processedSkill
             end


### PR DESCRIPTION
CSFv2 allows you to open skills using the `skillID` between the `CustomSkill` and `config` in a filename. This PR will re-enable that functionality.